### PR TITLE
Add Docker + Compose workflow for cactus-bot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+.git
+.gitignore
+.vscode
+data
+config/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: help build up down restart logs deploy ps
+
+help:
+	@echo "Available targets:"
+	@echo "  make build    Build Docker image"
+	@echo "  make up       Start bot container in background"
+	@echo "  make down     Stop and remove container"
+	@echo "  make restart  Restart bot container"
+	@echo "  make logs     Follow bot logs"
+	@echo "  make deploy   Deploy Discord slash commands"
+	@echo "  make ps       Show container status"
+
+build:
+	docker compose build
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+restart:
+	docker compose restart bot
+
+logs:
+	docker compose logs -f bot
+
+deploy:
+	docker compose run --rm bot npm run deploy-commands
+
+ps:
+	docker compose ps

--- a/README.md
+++ b/README.md
@@ -32,6 +32,46 @@ This is a Discord bot for the Tucsonians Discord server. The bot provides event 
 5. Deploy slash commands: `node deploy-commands.js`
 6. Start the bot: `node index.js`
 
+## Docker Setup
+
+### Prerequisites
+
+- Docker
+- Docker Compose (v2, `docker compose`)
+
+### Run with Docker
+
+1. Copy `config/config_sample.json` to `config/config.json` and fill in:
+   - `token`
+   - `clientId`
+   - `guildId`
+2. Build the image:
+   - `docker compose build`
+3. Deploy slash commands (run when commands change):
+   - `docker compose run --rm bot npm run deploy-commands`
+4. Start the bot:
+   - `docker compose up -d`
+5. View logs:
+   - `docker compose logs -f bot`
+6. Stop the bot:
+   - `docker compose down`
+
+Notes:
+- Event data is persisted in `./data` on your host.
+- `config/config.json` is mounted read-only into the container.
+
+### Makefile Shortcuts
+
+You can use the included `Makefile` for common Docker operations:
+
+- `make build` - Build the Docker image
+- `make up` - Start the bot in background
+- `make logs` - Follow bot logs
+- `make deploy` - Deploy slash commands
+- `make ps` - Show container status
+- `make restart` - Restart the bot container
+- `make down` - Stop and remove the container
+
 ### Available Commands
 
 - `/events` - List upcoming events (default: next 14 days)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  bot:
+    build: .
+    container_name: cactus-bot
+    restart: unless-stopped
+    volumes:
+      - ./config/config.json:/app/config/config.json:ro
+      - ./data:/app/data
+    command: npm start

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "## Overview",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js",
+    "deploy-commands": "node deploy-commands.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary\n- add Dockerfile for Node 20 runtime\n- add docker-compose service for the bot\n- add .dockerignore and Makefile shortcuts\n- update README with Docker and Makefile usage\n- add npm scripts for start and slash-command deploy\n\n## Validation\n- docker compose config\n- docker compose build\n- docker compose up -d\n- docker compose logs showed successful Discord login